### PR TITLE
arm-linux: refactor base image

### DIFF
--- a/.github/workflows/Dockerfile-arm.base
+++ b/.github/workflows/Dockerfile-arm.base
@@ -1,46 +1,14 @@
-# Ubuntu LTS as base image
-FROM ubuntu:24.04
-
 # These variables should be populated if building images outside the GitHub Actions workflow
 ARG TARGET
 ARG VERSION
+ARG REGISTRY_REPO
 
-# Container image description and details
-LABEL org.opencontainers.image.description="IAR Build Tools for ${TARGET} (CX)"
-LABEL org.opencontainers.image.ref_name="cx${TARGET}"
-LABEL org.opencontainers.image.source="https://iar.com"
-LABEL org.opencontainers.image.vendor="IAR Systems AB"
-LABEL org.opencontainers.image.version=${VERSION}
+# Re-use minimal image as base layer
+FROM ${REGISTRY_REPO}/${TARGET}:${VERSION}-minimal
 
-# Container environment variables
-ENV LC_ALL=C \
-DEBIAN_FRONTEND="noninteractive" \
-PATH=/opt/iar/cx${TARGET}/${TARGET}/bin:/opt/iar/cx${TARGET}/common/bin:$PATH \
-CC=icc${TARGET} \
-CXX=icc${TARGET} \
-ASM=iasm${TARGET} \
-HOME=/workdir
+# Reuse previous arguments in this stage
+ARG TARGET
+ARG VERSION
 
-# Linux-specific dependencies and conveniences
-RUN apt-get update \
-&& apt-get install -y --no-install-recommends \
-ca-certificates \
-libsqlite3-0 \
-libxml2 \
-tzdata \
-bzip2 \
-wget \
-git \
-libusb-1.0-0 \
-usbutils \
-&& rm -rf /var/lib/apt/lists/*
-
-# Intall IAR Build Tools and CMake
-RUN mkdir /opt/iar \
-&& wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-${VERSION}-linux-x86_64-base.tar.bz2" | tar --strip-components=1 -xj -C '/opt/iar' \
-&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.0.2/cmake-4.0.2-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local' \
-&& cd /opt/iar \
-&& ln -s cx${TARGET}-${VERSION} cx${TARGET}
-
-# Set the default work directory to ${HOME}
-WORKDIR ${HOME}
+# Intall additional IAR Build Tools
+RUN wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-${VERSION}-linux-x86_64-base.tar.bz2" | tar -I lbzip2 --skip-old-files --strip-components=1 -x -C '/opt/iar'

--- a/.github/workflows/Dockerfile-arm.device
+++ b/.github/workflows/Dockerfile-arm.device
@@ -15,4 +15,4 @@ ARG VARIANT
 ARG TIMESTAMP
 
 # Intall Device support
-RUN wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-device-support-${VARIANT}-${VERSION}.${TIMESTAMP}.tar.bz2" | tar --strip-components=1 -xj -C '/opt/iar'
+RUN wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-device-support-${VARIANT}-${VERSION}.${TIMESTAMP}.tar.bz2" | tar -I lbzip2 --strip-components=1 -x -C '/opt/iar'

--- a/.github/workflows/Dockerfile-arm.minimal
+++ b/.github/workflows/Dockerfile-arm.minimal
@@ -25,14 +25,14 @@ HOME=/workdir
 RUN apt-get update \
 && apt-get install -y --no-install-recommends \
 ca-certificates \
-bzip2 \
+lbzip2 \
 wget \
 git \
 && rm -rf /var/lib/apt/lists/*
 
 # Intall IAR Build Tools and CMake
 RUN mkdir /opt/iar \
-&& wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-${VERSION}-linux-x86_64-minimal.tar.bz2" | tar --strip-components=1 -xj -C '/opt/iar' \
+&& wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-${VERSION}-linux-x86_64-minimal.tar.bz2" | tar -I lbzip2 --strip-components=1 -x -C '/opt/iar' \
 && wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.0.2/cmake-4.0.2-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local' \
 && cd /opt/iar \
 && ln -s cx${TARGET}-${VERSION} cx${TARGET}

--- a/.github/workflows/arm-linux.yml
+++ b/.github/workflows/arm-linux.yml
@@ -16,19 +16,12 @@ permissions:
   packages: write
 
 jobs:
-  # Generate the -base image with the IAR Build tools for Arm
-  # *without* vendor-specific device support (tagged as :latest)
-  #
-  # The -minimal variant does not contain `cspybat`, `iarbuild` or `cstat`
-  # and it is suitable for faster fetching and/or simpler tasks
-  arm-core:
+  # The -minimal image can be fetched faster for simple tasks
+  arm-minimal:
     strategy:
       matrix:
         target: [ arm ]
         version: [ 9.60.4 ]
-        variant:
-        - base
-        - minimal
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main
@@ -38,31 +31,50 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - if: matrix.variant == 'minimal'
-      uses: docker/build-push-action@v6
+    - uses: docker/build-push-action@v6
       with:
-        file: ./.github/workflows/Dockerfile-${{ matrix.target }}.${{ matrix.variant }}
+        file: ./.github/workflows/Dockerfile-${{ matrix.target }}.minimal
         build-args: |
           TARGET=${{ matrix.target }}
           VERSION=${{ matrix.version }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: |
-          ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}:${{ matrix.version }}-${{ matrix.variant }}
-    - if: matrix.variant == 'base'
-      uses: docker/build-push-action@v6
-      with:
-        file: ./.github/workflows/Dockerfile-${{ matrix.target }}.${{ matrix.variant }}
-        build-args: |
-          TARGET=${{ matrix.target }}
-          VERSION=${{ matrix.version }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: |
-          ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}:${{ matrix.version }}-${{ matrix.variant }}
+          ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}:${{ matrix.version }}-minimal
 
+  # Generate the -base image with the IAR Build tools for Arm.
+  # It includes: -minimal, `cspybat`, `iarbuild` and `cstat`.
+  # It does not include: vendor-specific device support
+  arm-base:
+    needs: [ arm-minimal ]
+    strategy:
+      matrix:
+        target: [ arm ]
+        version: [ 9.60.4 ]
+        registry-repo: [ "ghcr.io/${{ github.repository_owner }}" ]
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@main
+    - if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: docker/build-push-action@v6
+      with:
+        file: ./.github/workflows/Dockerfile-${{ matrix.target }}.base
+        build-args: |
+          TARGET=${{ matrix.target }}
+          VERSION=${{ matrix.version }}
+          REGISTRY_REPO=${{ matrix.registry-repo }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: |
+          ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}:${{ matrix.version }}-base
+            
   # Generate variant images with the IAR Build Tools for Arm
-  # *with* vendor-specific device support
+  # *including* vendor-specific device support
   arm-device:
-    needs: [ arm-core ]
+    needs: [ arm-base ]
     strategy:
       matrix:
         target: [ arm ]


### PR DESCRIPTION
- Re-use `-minimal` for building `-base` for overhead reduction.
- Multi-threaded `.tar.bz2` decompression.
