### PR TITLE
cmake: update to 4.1.2

### DIFF
--- a/.github/workflows/linux/Dockerfile-arm.minimal
+++ b/.github/workflows/linux/Dockerfile-arm.minimal
@@ -33,7 +33,7 @@ git \
 # Intall IAR Build Tools and CMake
 RUN mkdir /opt/iar \
 && wget -qO- "https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-${VERSION}-linux-x86_64-minimal.tar.bz2" | tar -I lbzip2 -x -C '/opt/iar' \
-&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local' \
+&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local' \
 && cd /opt/iar \
 && ln -s cx${TARGET}-${VERSION} cx${TARGET}
 

--- a/.github/workflows/linux/Dockerfile-riscv.full
+++ b/.github/workflows/linux/Dockerfile-riscv.full
@@ -39,7 +39,7 @@ RUN wget -q https://netstorage.iar.com/FileStore/STANDARD/001/003/${LMSC_TAG}/ia
 && wget -q https://netstorage.iar.com/FileStore/STANDARD/001/003/${TARGET_TAG}/cx${TARGET}-${VERSION}.deb \
 && dpkg -i cx${TARGET}-${VERSION}.deb \
 && rm *.deb \
-&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local'
+&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local'
 
 # Set the default work directory to ${HOME}
 WORKDIR ${HOME}

--- a/.github/workflows/linux/Dockerfile-rl78.full
+++ b/.github/workflows/linux/Dockerfile-rl78.full
@@ -39,7 +39,7 @@ RUN wget -q https://netstorage.iar.com/FileStore/STANDARD/001/003/${LMSC_TAG}/ia
 && wget -q https://netstorage.iar.com/FileStore/STANDARD/001/003/${TARGET_TAG}/cx${TARGET}-${VERSION}.deb \
 && dpkg -i cx${TARGET}-${VERSION}.deb \
 && rm *.deb \
-&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local'
+&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local'
 
 # Set the default work directory to ${HOME}
 WORKDIR ${HOME}

--- a/.github/workflows/linux/Dockerfile-rx.full
+++ b/.github/workflows/linux/Dockerfile-rx.full
@@ -39,7 +39,7 @@ RUN wget -q https://netstorage.iar.com/FileStore/STANDARD/001/003/${LMSC_TAG}/ia
 && wget -q https://netstorage.iar.com/FileStore/STANDARD/001/003/${TARGET_TAG}/cx${TARGET}-${VERSION}.deb \
 && dpkg -i cx${TARGET}-${VERSION}.deb \
 && rm *.deb \
-&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local'
+&& wget -qO- 'https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-linux-x86_64.tar.gz' | tar --strip-components=1 -xz -C '/usr/local'
 
 # Set the default work directory to ${HOME}
 WORKDIR ${HOME}

--- a/.github/workflows/windows/Dockerfile-arm.base
+++ b/.github/workflows/windows/Dockerfile-arm.base
@@ -21,7 +21,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 
 # Install CMake
 RUN \
-Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip" -OutFile "cmake.zip"; \
+Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.zip" -OutFile "cmake.zip"; \
 Expand-Archive "cmake.zip" -DestinationPath "C:/";
 # Install Git
 RUN Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-busybox-64-bit.zip" -OutFile "git.zip"; \
@@ -34,7 +34,7 @@ RUN Invoke-WebRequest -Uri "https://github.com/iarsystems/${env:TARGET}/releases
 Expand-Archive "cxarm.zip" -DestinationPath "C:/iar";
 # Remove-Item "vc_redist.x64.exe", "*.zip";
 
-ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\${TARGET}\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.0-windows-x86_64\bin;C:\git\cmd"
+ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\${TARGET}\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.2-windows-x86_64\bin;C:\git\cmd"
 
 # Set the work directory
 WORKDIR "C:/workdir"

--- a/.github/workflows/windows/Dockerfile-arm.minimal
+++ b/.github/workflows/windows/Dockerfile-arm.minimal
@@ -17,7 +17,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ADD https://github.com/iarsystems/${TARGET}/releases/download/${VERSION}/cx${TARGET}-${VERSION}-windows-x86_64-minimal.zip cxarm.zip
-ADD https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip C:/cmake.zip
+ADD https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.zip C:/cmake.zip
 ADD https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-busybox-64-bit.zip C:/git.zip
 ADD https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip ninja-win.zip
 
@@ -36,10 +36,10 @@ FROM mcr.microsoft.com/windows/nanoserver:ltsc${WINVER}
 ARG TARGET
 ARG VERSION
 
-ENV PATH="C:\Windows;C:\Windows\System32;C:\iar\cx${TARGET}-${VERSION}\${TARGET}\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.0-windows-x86_64\bin;C:\git\cmd"
+ENV PATH="C:\Windows;C:\Windows\System32;C:\iar\cx${TARGET}-${VERSION}\${TARGET}\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.2-windows-x86_64\bin;C:\git\cmd"
 
 COPY --from=build ["C:/iar", "C:/iar"]
-COPY --from=build ["C:/cmake-4.1.0-windows-x86_64", "C:/cmake-4.1.0-windows-x86_64" ]
+COPY --from=build ["C:/cmake-4.1.2-windows-x86_64", "C:/cmake-4.1.2-windows-x86_64" ]
 COPY --from=build [ "C:/git", "C:/git" ]
 COPY --from=build [ "C:/Windows/ninja.exe", "C:/Windows/ninja.exe"]
 

--- a/.github/workflows/windows/Dockerfile-riscv.full
+++ b/.github/workflows/windows/Dockerfile-riscv.full
@@ -23,7 +23,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 
 # Install CMake
 RUN \
-Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip" -OutFile "cmake.zip"; \
+Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.zip" -OutFile "cmake.zip"; \
 Expand-Archive "cmake.zip" -DestinationPath "C:/";
 # Install Git
 RUN Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-busybox-64-bit.zip" -OutFile "git.zip"; \
@@ -40,7 +40,7 @@ Invoke-WebRequest -Uri "https://netstorage.iar.com/FileStore/STANDARD/001/003/${
 Start-Process -FilePath "cx${env:TARGET}-${env:VERSION}.exe" -ArgumentList "/hide_usd","/autoinstall" -wait; \
 Remove-Item "cx${env:TARGET}-${env:VERSION}.exe";
 
-ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\\${TARGET}\\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.0-windows-x86_64\bin;C:\git\cmd"
+ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\\${TARGET}\\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.2-windows-x86_64\bin;C:\git\cmd"
 
 # Set the work directory
 WORKDIR "C:/workdir"

--- a/.github/workflows/windows/Dockerfile-rl78.full
+++ b/.github/workflows/windows/Dockerfile-rl78.full
@@ -25,7 +25,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 
 # Install CMake
 RUN \
-Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip" -OutFile "cmake.zip"; \
+Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.zip" -OutFile "cmake.zip"; \
 Expand-Archive "cmake.zip" -DestinationPath "C:/";
 # Install Git
 RUN Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-busybox-64-bit.zip" -OutFile "git.zip"; \
@@ -42,7 +42,7 @@ Invoke-WebRequest -Uri "https://netstorage.iar.com/FileStore/STANDARD/001/003/${
 Start-Process -FilePath "cx${env:TARGET}-${env:VERSION}.exe" -ArgumentList "/hide_usd","/autoinstall" -wait; \
 Remove-Item "cx${env:TARGET}-${env:VERSION}.exe";
 
-ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\\${TARGET}\\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.0-windows-x86_64\bin;C:\git\cmd"
+ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\\${TARGET}\\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.2-windows-x86_64\bin;C:\git\cmd"
 
 # Set the work directory
 WORKDIR "C:/workdir"

--- a/.github/workflows/windows/Dockerfile-rx.full
+++ b/.github/workflows/windows/Dockerfile-rx.full
@@ -25,7 +25,7 @@ SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $Progress
 
 # Install CMake
 RUN \
-Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-windows-x86_64.zip" -OutFile "cmake.zip"; \
+Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v4.1.2/cmake-4.1.2-windows-x86_64.zip" -OutFile "cmake.zip"; \
 Expand-Archive "cmake.zip" -DestinationPath "C:/";
 # Install Git
 RUN Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-busybox-64-bit.zip" -OutFile "git.zip"; \
@@ -42,7 +42,7 @@ Invoke-WebRequest -Uri "https://netstorage.iar.com/FileStore/STANDARD/001/003/${
 Start-Process -FilePath "cx${env:TARGET}-${env:VERSION}.exe" -ArgumentList "/hide_usd","/autoinstall" -wait; \
 Remove-Item "cx${env:TARGET}-${env:VERSION}.exe";
 
-ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\\${TARGET}\\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.0-windows-x86_64\bin;C:\git\cmd"
+ENV PATH="C:\Windows;C:\Windows\System32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\iar\cx${TARGET}-${VERSION}\\${TARGET}\\bin;C:\iar\cx${TARGET}-${VERSION}\common\bin;C:\cmake-4.1.2-windows-x86_64\bin;C:\git\cmd"
 
 # Set the work directory
 WORKDIR "C:/workdir"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 >[!WARNING]
 >The information in this repository is subject to change without notice and does not constitute a commitment by IAR. While it serves as reference model for implementing Continuous Integration with IAR Tools, IAR assumes no responsibility for any errors, omissions, or specific implementations.
 
->[!CAUTION]
->An extraneous regression that affects `ASM` settings persistence for when __reconfiguring__ a project was introduced in CMake 4.1.0. A fix is planned for CMake [4.1.2](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11160).
-
 ## GitHub Actions workflow
 Pre-built container images are generated from annotated [workflows](.github/workflows) for the supported cloud-enabled products.
 


### PR DESCRIPTION
This PR updates CMake from v4.1.0 to v4.1.2.