### PR TITLE
Upgrade lmsc-daemon package to v1.9.1

### DIFF
--- a/.github/workflows/arm-linux.yml
+++ b/.github/workflows/arm-linux.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         target: [ arm ]
         cfg:
-        - { version: 9.70.1, lmsc-version: 1.8, lmsc-tag: 926 }
-        - { version: 9.60.4, lmsc-version: 1.8, lmsc-tag: 926 }
+        - { version: 9.70.1, lmsc-version: 1.9, lmsc-tag: 984 }
+        - { version: 9.60.4, lmsc-version: 1.9, lmsc-tag: 984 }
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main

--- a/.github/workflows/riscv-linux.yml
+++ b/.github/workflows/riscv-linux.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         target: [ riscv ]
         cfg:
-        - { version: 3.40.1, target-tag: 609, lmsc-version: 1.8, lmsc-tag: 926 }
+        - { version: 3.40.1, target-tag: 609, lmsc-version: 1.9, lmsc-tag: 984 }
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main

--- a/.github/workflows/rl78-linux.yml
+++ b/.github/workflows/rl78-linux.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         target: [ rl78 ]
         cfg:
-        - { version: 5.20.2, target-tag: 911, lmsc-version: 1.8, lmsc-tag: 926 }
-        - { version: 5.20.1, target-tag: 698, lmsc-version: 1.8, lmsc-tag: 926 }
+        - { version: 5.20.2, target-tag: 911, lmsc-version: 1.9, lmsc-tag: 984 }
+        - { version: 5.20.1, target-tag: 698, lmsc-version: 1.9, lmsc-tag: 984 }
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main

--- a/.github/workflows/rx-linux.yml
+++ b/.github/workflows/rx-linux.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         target: [ rx ]
         cfg:
-        - { version: 5.20.1, target-tag: 711, lmsc-version: 1.8, lmsc-tag: 926 }
+        - { version: 5.20.1, target-tag: 711, lmsc-version: 1.9, lmsc-tag: 984 }
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main


### PR DESCRIPTION
This PR updates LMSC DAEMON to v1.9.1 (includes `lmsc-daemon` v2.0.1).