### PR TITLE
Add CXRISCV 3.40.2

### DIFF
--- a/.github/workflows/riscv-linux.yml
+++ b/.github/workflows/riscv-linux.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         target: [ riscv ]
         cfg:
+        - { version: 3.40.2, target-tag: 671, lmsc-version: 1.9, lmsc-tag: 984 }
         - { version: 3.40.1, target-tag: 609, lmsc-version: 1.9, lmsc-tag: 984 }
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/riscv-windows.yml
+++ b/.github/workflows/riscv-windows.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         target: [ riscv ]
         cfg:
+        - { version: 3.40.2, target-tag: 670 }
         - { version: 3.40.1, target-tag: 650 }
         os: [ 2022, 2025 ]
     runs-on: windows-${{ matrix.os }}


### PR DESCRIPTION
This PR adds IAR Build Tools for RISC-V v3.40.2 to the build automation.