### PR TITLE
ci: Disable fail-fast for arm

### DIFF
--- a/.github/workflows/arm-linux.yml
+++ b/.github/workflows/arm-linux.yml
@@ -23,6 +23,7 @@ jobs:
         - { version: 9.70.2, lmsc-version: 1.11, lmsc-tag: 123 }
         - { version: 9.70.1, lmsc-version: 1.11, lmsc-tag: 123 }
         - { version: 9.60.4, lmsc-version: 1.11, lmsc-tag: 123 }
+      fail-fast: false
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main
@@ -53,6 +54,7 @@ jobs:
       matrix:
         target: [ arm ]
         version: [ 9.70.4, 9.70.2, 9.70.1, 9.60.4 ]
+      fail-fast: false
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main
@@ -93,6 +95,7 @@ jobs:
         - infineon
         - st
         - ti
+      fail-fast: false
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@main
@@ -132,6 +135,7 @@ jobs:
         - infineon
         - st
         - ti
+      fail-fast: false
     runs-on: ubuntu-24.04
     steps:
     - if: github.event_name != 'pull_request'
@@ -158,6 +162,7 @@ jobs:
         target: [ arm ]
         latest: [ 9.70.4 ]
         registry-repo: [ "ghcr.io/${{ github.repository_owner }}" ]
+      fail-fast: false
     runs-on: ubuntu-24.04
     steps:
     - if: github.event_name != 'pull_request'

--- a/.github/workflows/arm-windows.yml
+++ b/.github/workflows/arm-windows.yml
@@ -20,6 +20,7 @@ jobs:
         target: [ arm ]
         version: [ 9.70.4, 9.70.2, 9.70.1, 9.60.4 ]
         os: [ 2022, 2025 ]
+      fail-fast: false
     runs-on: windows-${{ matrix.os }}
     steps:
     - name: 'Checkout GitHub Action' 
@@ -49,6 +50,7 @@ jobs:
         target: [ arm ]
         version: [ 9.70.4, 9.70.2, 9.70.1, 9.60.4 ]
         os: [ 2022, 2025 ]
+      fail-fast: false
     runs-on: windows-${{ matrix.os }}
     steps:
     - name: 'Checkout GitHub Action' 
@@ -91,6 +93,7 @@ jobs:
         - infineon
         - st
         - ti
+      fail-fast: false
     runs-on: windows-${{ matrix.os }}
     steps:
     - uses: actions/checkout@main


### PR DESCRIPTION
This PR disables the CI's fail-fast for the arm build matrix so that, when/if a job fails, other jobs might continue independently until all images are created.